### PR TITLE
refactor: fix shared imports

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   api:
     image: node:20
     working_dir: /app
-    command: sh -lc "corepack enable && pnpm i && pnpm --filter @freelas/api dev"
+    command: sh -lc "corepack enable && pnpm i --force && pnpm --filter @freelas/api dev"
     volumes: ["..:/app"]
     environment:
       - API_PORT=3001
@@ -22,7 +22,7 @@ services:
   matcher:
     image: node:20
     working_dir: /app
-    command: sh -lc "corepack enable && pnpm i && pnpm --filter @freelas/matcher dev"
+    command: sh -lc "corepack enable && pnpm i --force && pnpm --filter @freelas/matcher dev"
     volumes: ["..:/app"]
     environment:
       - KAFKA_BROKERS=redpanda:9092

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./events": "./dist/events.js",
+    "./utils": "./dist/utils.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './events.js';
+export * from './utils.js';

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "outDir": "dist", "declaration": true },
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "rootDir": "src",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -6,7 +6,7 @@ import { Kafka } from "kafkajs";
 import Redis from "ioredis";
 import { z } from "zod";
 import { nanoid } from "nanoid";
-import { Topics } from "@freelas/shared/src/events";
+import { Topics } from "@freelas/shared";
 
 const PORT = Number(process.env.API_PORT || 3001);
 const KAFKA_BROKERS = (process.env.KAFKA_BROKERS || "localhost:19092").split(",");

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -1,1 +1,9 @@
-{ "extends":"../../tsconfig.base.json", "compilerOptions":{ "outDir":"dist" }, "include":["src"] }
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {}
+  },
+  "include": ["src"]
+}

--- a/services/matcher/src/index.ts
+++ b/services/matcher/src/index.ts
@@ -1,7 +1,6 @@
 import { Kafka } from "kafkajs";
 import Redis from "ioredis";
-import { Topics, ServiceRequest, ServiceOffer } from "@freelas/shared/src/events";
-import { etaMin, price } from "@freelas/shared/src/utils";
+import { Topics, ServiceRequest, ServiceOffer, etaMin, price } from "@freelas/shared";
 
 const kafka = new Kafka({ clientId:"freelas-matcher", brokers:(process.env.KAFKA_BROKERS||"localhost:19092").split(",") });
 const consumer = kafka.consumer({ groupId:"matcher" });

--- a/services/matcher/tsconfig.json
+++ b/services/matcher/tsconfig.json
@@ -1,1 +1,9 @@
-{ "extends":"../../tsconfig.base.json", "compilerOptions":{ "outDir":"dist" }, "include":["src"] }
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {}
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
+      "@freelas/shared": ["packages/shared/src"],
       "@freelas/shared/*": ["packages/shared/src/*"]
     }
   }


### PR DESCRIPTION
## Summary
- add explicit exports in shared package and index barrel file
- import shared utilities by package entry instead of deep src paths
- configure tsconfig paths/rootDir for clean builds
- run pnpm install with `--force` in docker-compose to avoid interactive reinstall prompts

## Testing
- `pnpm -r --filter "./packages/*" --filter "./services/*" --filter "./apps/*" run build`
- `docker compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a536f6387c832880e66b0cdbed9a1a