### PR TITLE
fix: resolve ESM imports in services

### DIFF
--- a/services/api/src/consumers.ts
+++ b/services/api/src/consumers.ts
@@ -1,6 +1,6 @@
 import { Topics } from "@freelas/shared";
 import type { Server } from "socket.io";
-import { consumer } from "./kafka";
+import { consumer } from "./kafka.js";
 
 export async function registerKafkaConsumers(io: Server) {
   await consumer.subscribe({ topic: Topics.ServiceOffer, fromBeginning: false });

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,5 +1,6 @@
 
-import { startServer } from "./server";
+// Explicit file extensions are required for Node.js ESM resolution
+import { startServer } from "./server.js";
 
 
 startServer().catch(err => {

--- a/services/api/src/kafka.ts
+++ b/services/api/src/kafka.ts
@@ -1,5 +1,5 @@
 import { Kafka } from "kafkajs";
-import { config } from "./config";
+import { config } from "./config.js";
 
 const kafka = new Kafka({ clientId: "freelas-api", brokers: config.kafkaBrokers });
 

--- a/services/api/src/redis.ts
+++ b/services/api/src/redis.ts
@@ -1,5 +1,5 @@
 import Redis from "ioredis";
-import { config } from "./config";
+import { config } from "./config.js";
 
 export const redis = new Redis(config.redisUrl);
 

--- a/services/api/src/routes/providers.ts
+++ b/services/api/src/routes/providers.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { nanoid } from "nanoid";
 import { Server } from "socket.io";
-import { redis, GEO_KEY, PROVIDER_KEY } from "../redis";
+import { redis, GEO_KEY, PROVIDER_KEY } from "../redis.js";
 
 export function registerProviderRoutes(app: FastifyInstance, io: Server) {
   app.post("/providers/register", async (req, rep) => {

--- a/services/api/src/routes/requests.ts
+++ b/services/api/src/routes/requests.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { nanoid } from "nanoid";
 import { Server } from "socket.io";
 import { Topics } from "@freelas/shared";
-import { redis, REQUEST_KEY, REQ_LOCK_KEY } from "../redis";
-import { producer } from "../kafka";
+import { redis, REQUEST_KEY, REQ_LOCK_KEY } from "../redis.js";
+import { producer } from "../kafka.js";
 
 export function registerRequestRoutes(app: FastifyInstance, io: Server) {
   app.post("/requests", async (req, rep) => {

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,11 +1,11 @@
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { config } from "./config";
-import { setupWebsocket } from "./websocket";
-import { initKafka } from "./kafka";
-import { registerKafkaConsumers } from "./consumers";
-import { registerProviderRoutes } from "./routes/providers";
-import { registerRequestRoutes } from "./routes/requests";
+import { config } from "./config.js";
+import { setupWebsocket } from "./websocket.js";
+import { initKafka } from "./kafka.js";
+import { registerKafkaConsumers } from "./consumers.js";
+import { registerProviderRoutes } from "./routes/providers.js";
+import { registerRequestRoutes } from "./routes/requests.js";
 
 export async function startServer() {
   const app = Fastify({ logger: true });

--- a/services/matcher/src/engine.ts
+++ b/services/matcher/src/engine.ts
@@ -1,6 +1,6 @@
 import { Topics, ServiceRequest, ServiceOffer, etaMin, price } from "@freelas/shared";
-import { consumer, producer } from "./kafka";
-import { redis, GEO_KEY, PROVIDER_KEY } from "./redis";
+import { consumer, producer } from "./kafka.js";
+import { redis, GEO_KEY, PROVIDER_KEY } from "./redis.js";
 
 export async function startMatcher() {
   await consumer.subscribe({ topic: Topics.ServiceRequested, fromBeginning: false });

--- a/services/matcher/src/index.ts
+++ b/services/matcher/src/index.ts
@@ -1,6 +1,6 @@
 
-import { initKafka } from "./kafka";
-import { startMatcher } from "./engine";
+import { initKafka } from "./kafka.js";
+import { startMatcher } from "./engine.js";
 
 async function main() {
   await initKafka();

--- a/services/matcher/src/kafka.ts
+++ b/services/matcher/src/kafka.ts
@@ -1,5 +1,5 @@
 import { Kafka } from "kafkajs";
-import { config } from "./config";
+import { config } from "./config.js";
 
 const kafka = new Kafka({ clientId: "freelas-matcher", brokers: config.kafkaBrokers });
 

--- a/services/matcher/src/redis.ts
+++ b/services/matcher/src/redis.ts
@@ -1,5 +1,5 @@
 import Redis from "ioredis";
-import { config } from "./config";
+import { config } from "./config.js";
 
 export const redis = new Redis(config.redisUrl);
 


### PR DESCRIPTION
## Summary
- ensure Node.js can resolve internal modules by using `.js` extensions in service imports

## Testing
- `pnpm --filter @freelas/shared build`
- `pnpm --filter @freelas/api build`
- `pnpm --filter @freelas/matcher build`
- `node services/api/dist/index.js` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*
- `node services/matcher/dist/index.js` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68a5efb475b483289e84dd48a13d1c54