### PR TITLE
feat(mobile): add basic login for client and provider

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -5,6 +5,8 @@ import { StatusBar } from "react-native";
 import ProviderScreen from "./src/screens/ProviderScreen";
 import ClientScreen from "./src/screens/ClientScreen";
 import OffersScreen from "./src/screens/OffersScreen";
+import LoginScreen from "./src/screens/LoginScreen";
+import { AuthProvider, useAuth } from "./src/contexts/AuthContext";
 
 export type RootTabParamList = {
   Prestador: undefined;
@@ -14,15 +16,35 @@ export type RootTabParamList = {
 
 const Tab = createBottomTabNavigator<RootTabParamList>();
 
-export default function App() {
+function Tabs() {
+  const { role } = useAuth();
   return (
-    <NavigationContainer>
-      <StatusBar barStyle="dark-content" />
-      <Tab.Navigator screenOptions={{ headerShown: true }}>
+    <Tab.Navigator screenOptions={{ headerShown: true }}>
+      {role === "provider" && (
         <Tab.Screen name="Prestador" component={ProviderScreen} />
+      )}
+      {role === "client" && (
         <Tab.Screen name="Cliente" component={ClientScreen} />
-        <Tab.Screen name="Ofertas" component={OffersScreen} />
-      </Tab.Navigator>
-    </NavigationContainer>
+      )}
+      <Tab.Screen name="Ofertas" component={OffersScreen} />
+    </Tab.Navigator>
   );
 }
+
+function Root() {
+  const { role } = useAuth();
+  if (!role) return <LoginScreen />;
+  return <Tabs />;
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <NavigationContainer>
+        <StatusBar barStyle="dark-content" />
+        <Root />
+      </NavigationContainer>
+    </AuthProvider>
+  );
+}
+

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState } from 'react';
+
+type Role = 'client' | 'provider';
+
+type AuthContextType = {
+  role: Role | null;
+  userId: string | null;
+  login: (role: Role, id: string) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType>({
+  role: null,
+  userId: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [role, setRole] = useState<Role | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+
+  const login = (r: Role, id: string) => {
+    setRole(r);
+    setUserId(id);
+  };
+
+  const logout = () => {
+    setRole(null);
+    setUserId(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ role, userId, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+

--- a/mobile/src/screens/ClientScreen.tsx
+++ b/mobile/src/screens/ClientScreen.tsx
@@ -6,10 +6,12 @@ import type { ServiceType } from "../types";
 import { useNavigation } from "@react-navigation/native";
 import type { RootTabParamList } from "../../App";
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function ClientScreen() {
   const nav = useNavigation<BottomTabNavigationProp<RootTabParamList>>();
   const [creating, setCreating] = useState(false);
+  const { userId } = useAuth();
 
   const createRequest = async () => {
     setCreating(true);
@@ -18,7 +20,7 @@ export default function ClientScreen() {
       if (status !== "granted") throw new Error("Sem permissão de localização.");
       const loc = await Location.getCurrentPositionAsync({});
       const body = {
-        clientId: "cli-demo",
+        clientId: userId ?? "cli-demo",
         serviceType: "plumber" as ServiceType,
         lat: loc.coords.latitude,
         lng: loc.coords.longitude,

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function LoginScreen() {
+  const { login } = useAuth();
+  const [role, setRole] = useState<'client' | 'provider'>('client');
+  const [id, setId] = useState('');
+
+  const doLogin = () => {
+    if (!id.trim()) return;
+    login(role, id.trim());
+  };
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.title}>Login</Text>
+      <View style={styles.switcher}>
+        <TouchableOpacity
+          style={[styles.switchBtn, role === 'client' && styles.switchBtnActive]}
+          onPress={() => setRole('client')}
+        >
+          <Text style={styles.switchText}>Cliente</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.switchBtn, role === 'provider' && styles.switchBtnActive]}
+          onPress={() => setRole('provider')}
+        >
+          <Text style={styles.switchText}>Prestador</Text>
+        </TouchableOpacity>
+      </View>
+      <TextInput
+        placeholder={role === 'client' ? 'ID do cliente' : 'ID do prestador'}
+        value={id}
+        onChangeText={setId}
+        autoCapitalize="none"
+        style={styles.input}
+      />
+      <TouchableOpacity style={styles.loginBtn} onPress={doLogin}>
+        <Text style={styles.loginText}>Entrar</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, padding: 16, gap: 16, justifyContent: 'center' },
+  title: { fontSize: 24, fontWeight: '700', textAlign: 'center' },
+  switcher: { flexDirection: 'row', justifyContent: 'center', gap: 8 },
+  switchBtn: { paddingVertical: 8, paddingHorizontal: 16, borderRadius: 8, borderWidth: 1, borderColor: '#ccc' },
+  switchBtnActive: { backgroundColor: '#111', borderColor: '#111' },
+  switchText: { color: '#000' },
+  input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 12 },
+  loginBtn: { backgroundColor: '#111', padding: 12, borderRadius: 8, alignItems: 'center' },
+  loginText: { color: '#fff', fontWeight: '700' },
+});
+

--- a/mobile/src/screens/ProviderScreen.tsx
+++ b/mobile/src/screens/ProviderScreen.tsx
@@ -9,6 +9,7 @@ import { useSocket } from "../hooks/useSocket";
 import AlertModal from "../components/AlertModal";
 import Constants from "expo-constants";
 import { Picker } from "@react-native-picker/picker";
+import { useAuth } from "../contexts/AuthContext";
 
 
 type Provider = { providerId: string; name?: string; lat?: number; lng?: number; isOnline?: boolean };
@@ -20,7 +21,8 @@ const DEFAULT_COORDS = { lat: -23.55052, lng: -46.633308 };
 const GOOGLE_MAPS_APIKEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY ?? "SUA_GOOGLE_KEY";
 
 export default function ProviderScreen() {
-  const [providerId] = useState(() => `prov-${Math.floor(Math.random() * 10000)}`);
+  const { userId } = useAuth();
+  const providerId = userId ?? `prov-${Math.floor(Math.random() * 10000)}`;
   const [pos, setPos] = useState<LatLng | null>(null);
   const [gpsLoading, setGpsLoading] = useState(true);
   const [netOnline, setNetOnline] = useState<boolean | null>(null);


### PR DESCRIPTION
## Summary
- add AuthContext and LoginScreen for simple role-based login
- show client or provider tabs based on login and reuse logged IDs in screens

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c23df3fe908328b6dffe52cd1a4dea