### PR TITLE
feat: track client orders and map fallback

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -7,11 +7,14 @@ import ClientScreen from "./src/screens/ClientScreen";
 import OffersScreen from "./src/screens/OffersScreen";
 import LoginScreen from "./src/screens/LoginScreen";
 import { AuthProvider, useAuth } from "./src/contexts/AuthContext";
+import OrdersScreen from "./src/screens/OrdersScreen";
+import { RequestsProvider } from "./src/contexts/RequestsContext";
 
 export type RootTabParamList = {
   Prestador: undefined;
   Cliente: undefined;
   Ofertas: { requestId?: string } | undefined;
+  Pedidos: undefined;
 };
 
 const Tab = createBottomTabNavigator<RootTabParamList>();
@@ -24,7 +27,10 @@ function Tabs() {
         <Tab.Screen name="Prestador" component={ProviderScreen} />
       )}
       {role === "client" && (
-        <Tab.Screen name="Cliente" component={ClientScreen} />
+        <>
+          <Tab.Screen name="Cliente" component={ClientScreen} />
+          <Tab.Screen name="Pedidos" component={OrdersScreen} />
+        </>
       )}
       <Tab.Screen name="Ofertas" component={OffersScreen} />
     </Tab.Navigator>
@@ -40,10 +46,12 @@ function Root() {
 export default function App() {
   return (
     <AuthProvider>
-      <NavigationContainer>
-        <StatusBar barStyle="dark-content" />
-        <Root />
-      </NavigationContainer>
+      <RequestsProvider>
+        <NavigationContainer>
+          <StatusBar barStyle="dark-content" />
+          <Root />
+        </NavigationContainer>
+      </RequestsProvider>
     </AuthProvider>
   );
 }

--- a/mobile/src/contexts/RequestsContext.tsx
+++ b/mobile/src/contexts/RequestsContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState } from "react";
+import type { ServiceType } from "../types";
+
+export type RequestItem = {
+  id: string;
+  serviceType: ServiceType;
+  status: "pending" | "accepted" | "completed";
+};
+
+type RequestsContextType = {
+  requests: RequestItem[];
+  addRequest: (id: string, serviceType: ServiceType) => void;
+  markAccepted: (id: string) => void;
+  completeRequest: (id: string) => void;
+};
+
+const RequestsContext = createContext<RequestsContextType>({
+  requests: [],
+  addRequest: () => {},
+  markAccepted: () => {},
+  completeRequest: () => {},
+});
+
+export const RequestsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [requests, setRequests] = useState<RequestItem[]>([]);
+
+  const addRequest = (id: string, serviceType: ServiceType) => {
+    setRequests(prev => [...prev, { id, serviceType, status: "pending" }]);
+  };
+
+  const markAccepted = (id: string) => {
+    setRequests(prev => prev.map(r => r.id === id ? { ...r, status: "accepted" } : r));
+  };
+
+  const completeRequest = (id: string) => {
+    setRequests(prev => prev.map(r => r.id === id ? { ...r, status: "completed" } : r));
+  };
+
+  return (
+    <RequestsContext.Provider value={{ requests, addRequest, markAccepted, completeRequest }}>
+      {children}
+    </RequestsContext.Provider>
+  );
+};
+
+export const useRequests = () => useContext(RequestsContext);
+

--- a/mobile/src/screens/ClientScreen.tsx
+++ b/mobile/src/screens/ClientScreen.tsx
@@ -7,13 +7,25 @@ import { useNavigation } from "@react-navigation/native";
 import type { RootTabParamList } from "../../App";
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import { useAuth } from "../contexts/AuthContext";
+import { useRequests } from "../contexts/RequestsContext";
 
 export default function ClientScreen() {
   const nav = useNavigation<BottomTabNavigationProp<RootTabParamList>>();
   const [creating, setCreating] = useState(false);
   const { userId } = useAuth();
+  const { addRequest, requests } = useRequests();
 
-  const createRequest = async () => {
+  const services: { type: ServiceType; label: string }[] = [
+    { type: "plumber", label: "Encanador" },
+    { type: "electrician", label: "Eletricista" },
+    { type: "carpenter", label: "Carpinteiro" },
+    { type: "general", label: "Serviço Geral" },
+  ];
+
+  const hasActive = (t: ServiceType) =>
+    requests.some(r => r.serviceType === t && r.status !== "completed");
+
+  const createRequest = async (serviceType: ServiceType) => {
     setCreating(true);
     try {
       const { status } = await Location.requestForegroundPermissionsAsync();
@@ -21,7 +33,7 @@ export default function ClientScreen() {
       const loc = await Location.getCurrentPositionAsync({});
       const body = {
         clientId: userId ?? "cli-demo",
-        serviceType: "plumber" as ServiceType,
+        serviceType,
         lat: loc.coords.latitude,
         lng: loc.coords.longitude,
         bairro: "Pinheiros",
@@ -51,6 +63,7 @@ export default function ClientScreen() {
       } else {
         nav.navigate("Ofertas", { requestId: data.requestId });
       }
+      addRequest(data.requestId, serviceType);
     } catch (e: any) {
       Alert.alert("Erro", e?.message ?? "Não foi possível criar pedido.");
     } finally {
@@ -62,9 +75,16 @@ export default function ClientScreen() {
     <View style={styles.root}>
       <Text style={styles.title}>Cliente</Text>
       <Text style={styles.sub}>Crie um pedido no seu local atual e veja ofertas chegando em tempo real.</Text>
-      <TouchableOpacity style={styles.btn} onPress={createRequest} disabled={creating}>
-        <Text style={styles.btnText}>{creating ? "Criando..." : "Pedir encanador aqui"}</Text>
-      </TouchableOpacity>
+      {services.map((s) => (
+        <TouchableOpacity
+          key={s.type}
+          style={[styles.btn, hasActive(s.type) && styles.btnDisabled]}
+          onPress={() => createRequest(s.type)}
+          disabled={creating || hasActive(s.type)}
+        >
+          <Text style={styles.btnText}>{s.label}</Text>
+        </TouchableOpacity>
+      ))}
     </View>
   );
 }
@@ -74,5 +94,6 @@ const styles = StyleSheet.create({
   title: { fontSize: 18, fontWeight: "700" },
   sub: { color: "#666" },
   btn: { backgroundColor: "#111", padding: 14, borderRadius: 12, alignItems: "center" },
-  btnText: { color: "#fff", fontWeight: "700" }
+  btnText: { color: "#fff", fontWeight: "700" },
+  btnDisabled: { opacity: 0.5 }
 });

--- a/mobile/src/screens/OffersScreen.tsx
+++ b/mobile/src/screens/OffersScreen.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from "../lib/api";
 import type { ServiceOffer } from "../types";
 import { Audio } from "expo-av";
 import AlertModal from "../components/AlertModal";
+import { useRequests } from "../contexts/RequestsContext";
 
 type RouteParams = { requestId?: string };
 
@@ -16,6 +17,7 @@ export default function OffersScreen() {
   const [offers, setOffers] = useState<ServiceOffer[]>([]);
   const [accepted, setAccepted] = useState<any | null>(null);
   const [newOfferModal, setNewOfferModal] = useState<{ providerId: string; price: number } | null>(null);
+  const { markAccepted } = useRequests();
 
 
   const loadOffers = async () => {
@@ -49,7 +51,10 @@ export default function OffersScreen() {
     if (!socket || !connected || !requestId) return;
     socket.emit("join", `request:${requestId}`);
 
-    const onAccepted = (data: any) => setAccepted(data);
+    const onAccepted = (data: any) => {
+      setAccepted(data);
+      markAccepted(data.requestId);
+    };
 
     socket.on("offer", onOffer);
     socket.on("accepted", onAccepted);
@@ -74,6 +79,7 @@ export default function OffersScreen() {
     }
     const data = await res.json();
     setAccepted(data.accepted);
+    markAccepted(requestId);
   };
 
   return (

--- a/mobile/src/screens/OrdersScreen.tsx
+++ b/mobile/src/screens/OrdersScreen.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
+import type { RootTabParamList } from "../../App";
+import { useRequests } from "../contexts/RequestsContext";
+
+export default function OrdersScreen() {
+  const { requests, completeRequest } = useRequests();
+  const nav = useNavigation<BottomTabNavigationProp<RootTabParamList>>();
+  const active = requests.filter(r => r.status !== "completed");
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.title}>Pedidos em andamento</Text>
+      <FlatList
+        data={active}
+        keyExtractor={(item) => item.id}
+        ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+        renderItem={({ item }) => (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>{item.serviceType}</Text>
+            <Text>Status: {item.status === "accepted" ? "Aceito" : "Aguardando"}</Text>
+            <View style={styles.row}>
+              <TouchableOpacity style={styles.btn} onPress={() => nav.navigate("Ofertas", { requestId: item.id })}>
+                <Text style={styles.btnText}>Ver ofertas</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.btn, styles.btnSecondary]} onPress={() => completeRequest(item.id)}>
+                <Text style={styles.btnText}>Concluir</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        )}
+        ListEmptyComponent={<Text style={styles.sub}>Nenhum pedido em andamento.</Text>}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, padding: 16, gap: 12 },
+  title: { fontSize: 18, fontWeight: "700" },
+  sub: { color: "#666" },
+  card: { backgroundColor: "#fff", padding: 12, borderRadius: 12, gap: 4, elevation: 3 },
+  cardTitle: { fontWeight: "700" },
+  row: { flexDirection: "row", gap: 8, marginTop: 8 },
+  btn: { flex: 1, backgroundColor: "#111", padding: 10, borderRadius: 10, alignItems: "center" },
+  btnSecondary: { backgroundColor: "#444" },
+  btnText: { color: "#fff", fontWeight: "700" },
+});
+

--- a/mobile/src/screens/ProviderScreen.tsx
+++ b/mobile/src/screens/ProviderScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, Alert, StyleSheet, TouchableOpacity, ActivityIndicator } from "react-native";
-import MapView, { Marker } from "react-native-maps";
+import MapView, { Marker, Polyline } from "react-native-maps";
 import MapViewDirections from "react-native-maps-directions";
 import * as Location from "expo-location";
 import * as Network from "expo-network";
@@ -142,6 +142,7 @@ export default function ProviderScreen() {
 
   const coords = pos ?? DEFAULT_COORDS;
   const canCallApi = apiOnline === true;
+  const hasGoogleKey = GOOGLE_MAPS_APIKEY && GOOGLE_MAPS_APIKEY !== "SUA_GOOGLE_KEY";
 
   const goOnline = async () => {
     if (!pos) { Alert.alert("Localização necessária", "Ative a localização para ficar online."); return; }
@@ -229,23 +230,31 @@ export default function ProviderScreen() {
         {dest && (
           <>
             <Marker coordinate={dest} title="Cliente" />
-            <MapViewDirections
-              origin={origin}
-              destination={dest}
-              apikey={GOOGLE_MAPS_APIKEY}
-              strokeWidth={5}
-              strokeColor="#1E3A8A"
-              optimizeWaypoints
-              mode="DRIVING"
-              onReady={(res) => {
-                // fit animado de toda a rota (efeito Uber)
-                mapRef.current?.fitToCoordinates(res.coordinates, {
-                  edgePadding: { top: 120, right: 60, bottom: 320, left: 60 },
-                  animated: true
-                });
-              }}
-              onError={(e) => console.log("Directions error:", e)}
-            />
+            {hasGoogleKey ? (
+              <MapViewDirections
+                origin={origin}
+                destination={dest}
+                apikey={GOOGLE_MAPS_APIKEY}
+                strokeWidth={5}
+                strokeColor="#1E3A8A"
+                optimizeWaypoints
+                mode="DRIVING"
+                onReady={(res) => {
+                  // fit animado de toda a rota (efeito Uber)
+                  mapRef.current?.fitToCoordinates(res.coordinates, {
+                    edgePadding: { top: 120, right: 60, bottom: 320, left: 60 },
+                    animated: true
+                  });
+                }}
+                onError={(e) => console.log("Directions error:", e)}
+              />
+            ) : (
+              <Polyline
+                coordinates={[origin, dest]}
+                strokeWidth={5}
+                strokeColor="#1E3A8A"
+              />
+            )}
           </>
         )}
       </MapView>


### PR DESCRIPTION
## Summary
- add request tracking context and "Pedidos" tab
- disable services with active requests
- fallback polyline map when Google directions unavailable

## Testing
- `cd api && yarn test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*
- `cd mobile && yarn tsc --noEmit` *(fails: Cannot find module 'expo-constants')*


------
https://chatgpt.com/codex/tasks/task_e_68c3969604888328953f4bfcfaf9ab0f