### PR TITLE
feat: add order tracking and google maps

### DIFF
--- a/mobile/src/screens/OffersScreen.tsx
+++ b/mobile/src/screens/OffersScreen.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
-import { useRoute } from "@react-navigation/native";
+import { useRoute, useNavigation } from "@react-navigation/native";
+import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
+import type { RootTabParamList } from "../../App";
 import { useSocket } from "../hooks/useSocket";
 import { apiFetch } from "../lib/api";
 import type { ServiceOffer } from "../types";
@@ -12,6 +14,7 @@ type RouteParams = { requestId?: string };
 
 export default function OffersScreen() {
   const route = useRoute();
+  const nav = useNavigation<BottomTabNavigationProp<RootTabParamList>>();
   const { requestId } = (route.params as RouteParams) || {};
   const { socket, connected } = useSocket();
   const [offers, setOffers] = useState<ServiceOffer[]>([]);
@@ -85,6 +88,9 @@ export default function OffersScreen() {
   return (
     <View style={styles.root}>
       <Text style={styles.title}>Ofertas</Text>
+      <TouchableOpacity style={styles.trackBtn} onPress={() => nav.navigate("Pedidos")}>
+        <Text style={styles.btnText}>Pedidos em andamento</Text>
+      </TouchableOpacity>
       {!requestId && <Text style={styles.sub}>Crie um pedido na aba Cliente.</Text>}
       {accepted && (
         <View style={styles.accepted}>
@@ -104,7 +110,11 @@ export default function OffersScreen() {
             <Text>Distância: {item.distanceKm.toFixed(2)} km</Text>
             <Text>ETA: {item.etaMin} min</Text>
             <Text>Preço estimado: R$ {item.priceEstimate.toFixed(2)}</Text>
-            <TouchableOpacity style={styles.btn} onPress={() => accept(item)}>
+            <TouchableOpacity
+              style={[styles.btn, accepted && styles.btnDisabled]}
+              onPress={() => accept(item)}
+              disabled={!!accepted}
+            >
               <Text style={styles.btnText}>Aceitar</Text>
             </TouchableOpacity>
           </View>
@@ -137,7 +147,9 @@ const styles = StyleSheet.create({
   sub: { color: "#666" },
   card: { backgroundColor: "#fff", padding: 12, borderRadius: 12, elevation: 3 },
   cardTitle: { fontWeight: "700", marginBottom: 4 },
+  trackBtn: { backgroundColor: "#111", padding: 10, borderRadius: 10, alignItems: "center", marginBottom: 8 },
   btn: { marginTop: 8, backgroundColor: "#111", padding: 10, borderRadius: 10, alignItems: "center" },
   btnText: { color: "#fff", fontWeight: "700" },
+  btnDisabled: { opacity: 0.5 },
   accepted: { backgroundColor: "#E6FFED", borderRadius: 12, padding: 12, gap: 4 }
 });

--- a/web/package.json
+++ b/web/package.json
@@ -10,15 +10,14 @@
     "start": "next start -p 3000"
   },
   "dependencies": {
-    "leaflet": "^1.9.4",
+    "@react-google-maps/api": "^2.20.1",
     "next": "^14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-leaflet": "^4",
     "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
-    "@types/leaflet": "^1.9.12",
+    "@types/google.maps": "^3.55.5",
     "@types/node": "^20.14.9",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^19.1.7",

--- a/web/src/Map.tsx
+++ b/web/src/Map.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { MapContainer, TileLayer, Marker, Polyline, Popup } from "react-leaflet";
-import "leaflet/dist/leaflet.css";
+import React, { useEffect, useState } from "react";
+import { GoogleMap, Marker, DirectionsRenderer, useJsApiLoader } from "@react-google-maps/api";
 
 export default function Map({
   client,
@@ -9,22 +9,50 @@ export default function Map({
   client: { lat: number; lng: number };
   provider?: { lat: number; lng: number };
 }) {
-  if (typeof window === "undefined") return null; // guarda extra
+  const { isLoaded } = useJsApiLoader({
+    id: "google-map",
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "",
+  });
+  const [directions, setDirections] = useState<google.maps.DirectionsResult | null>(null);
+
+  useEffect(() => {
+    if (!isLoaded || !provider) return;
+    const service = new google.maps.DirectionsService();
+    service.route(
+      { origin: client, destination: provider, travelMode: google.maps.TravelMode.DRIVING },
+      (res, status) => {
+        if (status === google.maps.DirectionsStatus.OK && res) {
+          setDirections(res);
+        }
+      }
+    );
+  }, [isLoaded, client, provider]);
+
+  if (!isLoaded) return <p>Mapa não disponível</p>;
+
+  const eta = directions?.routes?.[0]?.legs?.[0]?.duration?.text;
 
   return (
-    <MapContainer center={[client.lat, client.lng]} zoom={13} style={{ height: "100%", width: "100%" }}>
-      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-      <Marker position={[client.lat, client.lng]}>
-        <Popup>Cliente</Popup>
-      </Marker>
-      {provider && (
-        <>
-          <Marker position={[provider.lat, provider.lng]}>
-            <Popup>Prestador</Popup>
-          </Marker>
-          <Polyline positions={[[client.lat, client.lng], [provider.lat, provider.lng]]} />
-        </>
+    <GoogleMap mapContainerStyle={{ height: "100%", width: "100%" }} center={client} zoom={13}>
+      <Marker position={client} label="C" />
+      {provider && <Marker position={provider} label="P" />}
+      {directions && <DirectionsRenderer directions={directions} options={{ suppressMarkers: true }} />}
+      {eta && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: 8,
+            left: 8,
+            background: "#fff",
+            padding: "4px 8px",
+            borderRadius: 4,
+            boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
+          }}
+        >
+          Chegada {eta}
+        </div>
       )}
-    </MapContainer>
+    </GoogleMap>
   );
 }
+


### PR DESCRIPTION
## Summary
- add navigation to ongoing orders from offers list
- switch web map to Google Maps with directions and ETA

## Testing
- `cd web && yarn install` *(fails: tunneling socket could not be established, statusCode=403)*
- `cd web && npx tsc --noEmit` *(fails: Cannot find module '@react-google-maps/api' or its corresponding type declarations, etc.)*
- `cd mobile && npx tsc --noEmit` *(fails: Cannot find module 'expo-constants', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c39a2103488328b8e4bccdca42a4c1